### PR TITLE
Fix status labels and translations

### DIFF
--- a/src/pages/bed/Bed.js
+++ b/src/pages/bed/Bed.js
@@ -75,7 +75,7 @@ export default function Bed({ route, navigation }) {
         (userConfig.permission !== "admin" &&
           userConfig.permission !== "enfermeira"))
     ) {
-      let status = isMaintenance ? "manutenção" : "bloqueado";
+      let status = isMaintenance ? "manutenção" : "interditado";
 
       showMessage(
         "error",
@@ -204,7 +204,7 @@ export default function Bed({ route, navigation }) {
                   onValueChange: handleMaintenanceChange,
                 },
                 {
-                  label: "Bloqueado",
+                  label: "Interditado",
                   value: isBlocked,
                   onValueChange: handleBlockedChange,
                 },

--- a/src/pages/home/BedStatusPage.js
+++ b/src/pages/home/BedStatusPage.js
@@ -103,7 +103,7 @@ export default function BedStatusPage({ route, navigation }) {
                 maintenance={true}
               />
               <BedCard
-                title="Leitos Bloqueados"
+                title="Leitos Interditados"
                 beds={bedCounts.blocked}
                 color={_getColor("blocked")}
                 navigation={navigation}

--- a/src/pages/home/components/BedListPage.js
+++ b/src/pages/home/components/BedListPage.js
@@ -14,16 +14,12 @@ export default function BedListPage({ route, navigation }) {
   useEffect(() => {
     const fetchData = async () => {
       let bedsArrays;
-      if (maintenance) {
-        bedsArrays = await BedsService.getBedsByConditions({
-          maintenance,
-          section,
-        });
-      } else if (blocked) {
-        bedsArrays = await BedsService.getBedsByConditions({
-          blocked,
-          section,
-        });
+      const conditions = {};
+
+      if (typeof maintenance === "boolean") {
+        conditions.isMaintenance = maintenance;
+      } else if (typeof blocked === "boolean") {
+        conditions.isBlocked = blocked;
       } else {
         const statusList = parse(status);
         const bedsPromises = Array.isArray(statusList)
@@ -35,6 +31,15 @@ export default function BedListPage({ route, navigation }) {
           : [];
         bedsArrays = await Promise.all(bedsPromises);
       }
+
+      if (section) {
+        conditions.section = section;
+      }
+
+      if (Object.keys(conditions).length > 0) {
+        bedsArrays = await BedsService.getBedsByConditions(conditions);
+      }
+
       const combinedBeds = Array.isArray(bedsArrays)
         ? bedsArrays.flat()
         : bedsArrays;

--- a/src/pages/home/hook/useFetchBedStatusData.js
+++ b/src/pages/home/hook/useFetchBedStatusData.js
@@ -76,11 +76,11 @@ export const useFetchBedStatusData = (section) => {
           );
 
           bedCounts.maintenance = await BedsService.getCountBy({
-            maintenance: true,
+            isMaintenance: true,
             section,
           });
           bedCounts.blocked = await BedsService.getCountBy({
-            blocked: true,
+            isBlocked: true,
             section,
           });
 

--- a/src/shared/utils/constantsUtils.js
+++ b/src/shared/utils/constantsUtils.js
@@ -153,7 +153,7 @@ export const translateStatusConstant = {
   cleaning_in_progress: "Fim de higienização", // Mudança de tradução
   awaiting_for_bedding: "Início de forragem", // Mudança de tradução
   bedding_in_progress: "Fim de forragem", // Mudança de tradução
-  blocked: "Bloqueado",
+  blocked: "Interditado",
   maintenance: "Em manutenção",
   // 'final_discharge': "Alta final"  // Remover se não necessário
 };


### PR DESCRIPTION
The commits in this pull request fix the status labels and translations in the code. The "blocked" status label is changed to "interditado" and the translations for various status constants are updated. This ensures that the status labels and translations are accurate and consistent throughout the codebase.